### PR TITLE
HotplugWatcher_GUI - fix string passing, no need for qPrintable

### DIFF
--- a/test/main_gui.cpp
+++ b/test/main_gui.cpp
@@ -29,18 +29,17 @@ static HotplugWatcher_GUI *gui = 0;
 void MsgOuput(QtMsgType type, const char *msg)
 {
 #else
-void MsgOuput(QtMsgType type, const QMessageLogContext &, const QString& qmsg)
+void MsgOuput(QtMsgType type, const QMessageLogContext &, const QString& msg)
 {
-    const char* msg = qPrintable(qmsg);
 #endif
-	Q_UNUSED(type);
+	Q_UNUSED(type)
 	if (gui)
 		gui->appendMessage(msg);
 }
 
 int main(int argc, char *argv[])
 {
-    qInstallMessageHandler(MsgOuput);
+	qInstallMessageHandler(MsgOuput);
 	QApplication a(argc, argv);
 
 	HotplugWatcher_GUI hotplug;


### PR DESCRIPTION
In the first case of the #if msg is of type "const char *" and will be
converted to a valid QString automatically. In the #else branch (Qt >=
5.0.0) we simply pass the QString on to gui->appendMessage().

This patches fixes garbage output on the screen, e.g. all messages were
shown as "**********************" on Qt 5.9.4 on Windows 10.