### PR TITLE
Add Qt6 support for win32

### DIFF
--- a/src/qdevicewatcher_mac.cpp
+++ b/src/qdevicewatcher_mac.cpp
@@ -53,6 +53,7 @@ bool QDeviceWatcherPrivate::start()
 {
     init();
     QThread::start();
+    return true;
 }
 
 bool QDeviceWatcherPrivate::stop()
@@ -62,6 +63,7 @@ bool QDeviceWatcherPrivate::stop()
     //DAUnregisterApprovalCallback
     DAUnregisterCallback(mSession, (void *) onDiskAppear, this);
     DAUnregisterCallback(mSession, (void *) onDiskDisappear, this);
+    return true;
 }
 
 void QDeviceWatcherPrivate::parseDeviceInfo() {}
@@ -74,6 +76,7 @@ bool QDeviceWatcherPrivate::init()
 
     DARegisterDiskAppearedCallback(mSession, NULL, onDiskAppear, this);
     DARegisterDiskDisappearedCallback(mSession, NULL, onDiskDisappear, this);
+    return true;
 }
 
 void QDeviceWatcherPrivate::run()

--- a/src/qdevicewatcher_win32.cpp
+++ b/src/qdevicewatcher_win32.cpp
@@ -55,8 +55,6 @@ static const GUID InterfaceClassGuid
     = GUID_DEVINTERFACE_USBSTOR; //(GUID)HID_CLASSGUID; //GUID_DEVINTERFACE_USBSTOR
 #endif                           //CONFIG_NOTIFICATION
 
-Q_CORE_EXPORT HINSTANCE qWinAppInst();
-
 static inline QStringList drivesFromMask(quint32 driveBits) //driveBits ->unitmask
 {
     QStringList ret;
@@ -296,7 +294,7 @@ static inline QString className()
 static inline HWND dw_create_internal_window(const void *userData)
 {
     QString className = ::className();
-    HINSTANCE hi = qWinAppInst();
+    HINSTANCE hi = GetModuleHandle(0);
 
     WNDCLASS wc;
     wc.style = 0;
@@ -361,7 +359,7 @@ static inline void dw_destroy_internal_window(HWND hwnd)
 #if CONFIG_NOTIFICATION
     UnregisterDeviceNotification(hDevNotify);
 #endif
-    UnregisterClass(reinterpret_cast<const wchar_t *>(className().utf16()), qWinAppInst());
+    UnregisterClass(reinterpret_cast<const wchar_t *>(className().utf16()), GetModuleHandle(0));
 }
 
 QDeviceWatcherPrivate::~QDeviceWatcherPrivate()

--- a/src/qdevicewatcher_win32.cpp
+++ b/src/qdevicewatcher_win32.cpp
@@ -294,7 +294,7 @@ static inline QString className()
 static inline HWND dw_create_internal_window(const void *userData)
 {
     QString className = ::className();
-    HINSTANCE hi = GetModuleHandle(0);
+    HINSTANCE hi = GetModuleHandle(NULL);
 
     WNDCLASS wc;
     wc.style = 0;
@@ -359,7 +359,7 @@ static inline void dw_destroy_internal_window(HWND hwnd)
 #if CONFIG_NOTIFICATION
     UnregisterDeviceNotification(hDevNotify);
 #endif
-    UnregisterClass(reinterpret_cast<const wchar_t *>(className().utf16()), GetModuleHandle(0));
+    UnregisterClass(reinterpret_cast<const wchar_t *>(className().utf16()), GetModuleHandle(NULL));
 }
 
 QDeviceWatcherPrivate::~QDeviceWatcherPrivate()


### PR DESCRIPTION
This commit fixes the code to build on Qt6, where qWinAppInst() was removed.

It was removed via https://github.com/qt/qtbase/commit/64507c7165e42c2a5029353d8f97a0d841fa6b01